### PR TITLE
Explicitly add the backup extension for `sed -i`

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -7,7 +7,7 @@
   "author": "faris@repl.it",
   "license": "MIT",
   "scripts": {
-    "prepublishOnly": "pbjs --force-number --force-message -t static-module -w default -o index.js ../api.proto && ./tools/jsdoc.js < index.js > .index.js && mv .index.js index.js && pbts -o index.d.ts index.js && sed -i 's/constructor(/private constructor(/' index.d.ts && flowgen --interface-records --no-inexact --add-flow-header index.d.ts && ./tools/flow.js < export.flow.js > .export.flow.js && mv .export.flow.js export.flow.js"
+    "prepublishOnly": "pbjs --force-number --force-message -t static-module -w default -o index.js ../api.proto && ./tools/jsdoc.js < index.js > .index.js && mv .index.js index.js && pbts -o index.d.ts index.js && sed -i .bak 's/constructor(/private constructor(/' index.d.ts && flowgen --interface-records --no-inexact --add-flow-header index.d.ts && ./tools/flow.js < export.flow.js > .export.flow.js && mv .export.flow.js export.flow.js"
   },
   "dependencies": {
     "protobufjs": "^6.10.2"


### PR DESCRIPTION
This change makes the `sed` command work in all POSIX. Concretely, folks
should now be able to publish packages from macOS.