### PR TITLE
Add messages for intermediate signed messages

### DIFF
--- a/client.proto
+++ b/client.proto
@@ -194,13 +194,6 @@ message ReplToken {
   Permissions permissions = 15;
 }
 
-// GovalTokenMetadata is information about a goval token, that can be used to
-// validate it. It is stored in the footer of the PASETO.
-message GovalTokenMetadata {
-  // The ID of the key that was used to sign the token.
-  string key_id = 1;
-}
-
 // TLSCertificate is a SSL/TLS certificate for a specific domain. This is used to transfer
 // certificates between clusters when a repl is transferred so we do not need to request
 // a new certificate in the new cluster.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -13792,96 +13792,6 @@ export namespace api {
         }
     }
 
-    /** Properties of a GovalTokenMetadata. */
-    interface IGovalTokenMetadata {
-
-        /** GovalTokenMetadata keyId */
-        keyId?: (string|null);
-    }
-
-    /** Represents a GovalTokenMetadata. */
-    class GovalTokenMetadata {
-
-        /**
-         * Constructs a new GovalTokenMetadata.
-         * @param [properties] Properties to set
-         */
-        private constructor(properties?: api.IGovalTokenMetadata);
-
-        /** GovalTokenMetadata keyId. */
-        public keyId: string;
-
-        /**
-         * Creates a new GovalTokenMetadata instance using the specified properties.
-         * @param [properties] Properties to set
-         * @returns GovalTokenMetadata instance
-         */
-        public static create(properties?: api.IGovalTokenMetadata): api.GovalTokenMetadata;
-
-        /**
-         * Encodes the specified GovalTokenMetadata message. Does not implicitly {@link api.GovalTokenMetadata.verify|verify} messages.
-         * @param message GovalTokenMetadata message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encode(message: api.GovalTokenMetadata, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Encodes the specified GovalTokenMetadata message, length delimited. Does not implicitly {@link api.GovalTokenMetadata.verify|verify} messages.
-         * @param message GovalTokenMetadata message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encodeDelimited(message: api.GovalTokenMetadata, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Decodes a GovalTokenMetadata message from the specified reader or buffer.
-         * @param reader Reader or buffer to decode from
-         * @param [length] Message length if known beforehand
-         * @returns GovalTokenMetadata
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): api.GovalTokenMetadata;
-
-        /**
-         * Decodes a GovalTokenMetadata message from the specified reader or buffer, length delimited.
-         * @param reader Reader or buffer to decode from
-         * @returns GovalTokenMetadata
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): api.GovalTokenMetadata;
-
-        /**
-         * Verifies a GovalTokenMetadata message.
-         * @param message Plain object to verify
-         * @returns `null` if valid, otherwise the reason why it is not
-         */
-        public static verify(message: { [k: string]: any }): (string|null);
-
-        /**
-         * Creates a GovalTokenMetadata message from a plain object. Also converts values to their respective internal types.
-         * @param object Plain object
-         * @returns GovalTokenMetadata
-         */
-        public static fromObject(object: { [k: string]: any }): api.GovalTokenMetadata;
-
-        /**
-         * Creates a plain object from a GovalTokenMetadata message. Also converts values to other types if specified.
-         * @param message GovalTokenMetadata
-         * @param [options] Conversion options
-         * @returns Plain object
-         */
-        public static toObject(message: api.GovalTokenMetadata, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-        /**
-         * Converts this GovalTokenMetadata to JSON.
-         * @returns JSON object
-         */
-        public toJSON(): { [k: string]: any };
-    }
-
     /** Properties of a TLSCertificate. */
     interface ITLSCertificate {
 
@@ -14495,6 +14405,447 @@ export namespace api {
 
         /**
          * Converts this EvictReplResponse to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** TokenVersion enum. */
+    enum TokenVersion {
+        BARE_REPL_TOKEN = 0,
+        TYPE_AWARE_TOKEN = 1
+    }
+
+    /** Properties of a GovalSigningAuthority. */
+    interface IGovalSigningAuthority {
+
+        /** GovalSigningAuthority keyId */
+        keyId?: (string|null);
+
+        /** GovalSigningAuthority signedCert */
+        signedCert?: (string|null);
+
+        /** GovalSigningAuthority version */
+        version?: (api.TokenVersion|null);
+    }
+
+    /** Represents a GovalSigningAuthority. */
+    class GovalSigningAuthority {
+
+        /**
+         * Constructs a new GovalSigningAuthority.
+         * @param [properties] Properties to set
+         */
+        private constructor(properties?: api.IGovalSigningAuthority);
+
+        /** GovalSigningAuthority keyId. */
+        public keyId: string;
+
+        /** GovalSigningAuthority signedCert. */
+        public signedCert: string;
+
+        /** GovalSigningAuthority version. */
+        public version: api.TokenVersion;
+
+        /** GovalSigningAuthority cert. */
+        public cert?: ("keyId"|"signedCert");
+
+        /**
+         * Creates a new GovalSigningAuthority instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns GovalSigningAuthority instance
+         */
+        public static create(properties?: api.IGovalSigningAuthority): api.GovalSigningAuthority;
+
+        /**
+         * Encodes the specified GovalSigningAuthority message. Does not implicitly {@link api.GovalSigningAuthority.verify|verify} messages.
+         * @param message GovalSigningAuthority message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: api.GovalSigningAuthority, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified GovalSigningAuthority message, length delimited. Does not implicitly {@link api.GovalSigningAuthority.verify|verify} messages.
+         * @param message GovalSigningAuthority message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: api.GovalSigningAuthority, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a GovalSigningAuthority message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns GovalSigningAuthority
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): api.GovalSigningAuthority;
+
+        /**
+         * Decodes a GovalSigningAuthority message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns GovalSigningAuthority
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): api.GovalSigningAuthority;
+
+        /**
+         * Verifies a GovalSigningAuthority message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a GovalSigningAuthority message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns GovalSigningAuthority
+         */
+        public static fromObject(object: { [k: string]: any }): api.GovalSigningAuthority;
+
+        /**
+         * Creates a plain object from a GovalSigningAuthority message. Also converts values to other types if specified.
+         * @param message GovalSigningAuthority
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: api.GovalSigningAuthority, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this GovalSigningAuthority to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** FlagClaim enum. */
+    enum FlagClaim {
+        MINT_GOVAL_TOKEN = 0,
+        SIGN_INTERMEDIATE_CERT = 1
+    }
+
+    /** Properties of a CertificateClaim. */
+    interface ICertificateClaim {
+
+        /** CertificateClaim replid */
+        replid?: (string|null);
+
+        /** CertificateClaim user */
+        user?: (string|null);
+
+        /** CertificateClaim flag */
+        flag?: (api.FlagClaim|null);
+    }
+
+    /** Represents a CertificateClaim. */
+    class CertificateClaim {
+
+        /**
+         * Constructs a new CertificateClaim.
+         * @param [properties] Properties to set
+         */
+        private constructor(properties?: api.ICertificateClaim);
+
+        /** CertificateClaim replid. */
+        public replid: string;
+
+        /** CertificateClaim user. */
+        public user: string;
+
+        /** CertificateClaim flag. */
+        public flag: api.FlagClaim;
+
+        /** CertificateClaim claim. */
+        public claim?: ("replid"|"user"|"flag");
+
+        /**
+         * Creates a new CertificateClaim instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns CertificateClaim instance
+         */
+        public static create(properties?: api.ICertificateClaim): api.CertificateClaim;
+
+        /**
+         * Encodes the specified CertificateClaim message. Does not implicitly {@link api.CertificateClaim.verify|verify} messages.
+         * @param message CertificateClaim message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: api.CertificateClaim, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified CertificateClaim message, length delimited. Does not implicitly {@link api.CertificateClaim.verify|verify} messages.
+         * @param message CertificateClaim message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: api.CertificateClaim, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a CertificateClaim message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns CertificateClaim
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): api.CertificateClaim;
+
+        /**
+         * Decodes a CertificateClaim message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns CertificateClaim
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): api.CertificateClaim;
+
+        /**
+         * Verifies a CertificateClaim message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a CertificateClaim message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns CertificateClaim
+         */
+        public static fromObject(object: { [k: string]: any }): api.CertificateClaim;
+
+        /**
+         * Creates a plain object from a CertificateClaim message. Also converts values to other types if specified.
+         * @param message CertificateClaim
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: api.CertificateClaim, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this CertificateClaim to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of a GovalCert. */
+    interface IGovalCert {
+
+        /** GovalCert iat */
+        iat?: (google.protobuf.Timestamp|google.protobuf.ITimestamp|null);
+
+        /** GovalCert exp */
+        exp?: (google.protobuf.Timestamp|google.protobuf.ITimestamp|null);
+
+        /** GovalCert claims */
+        claims?: ((api.CertificateClaim|api.ICertificateClaim)[]|null);
+
+        /** GovalCert publicKey */
+        publicKey?: (string|null);
+    }
+
+    /** Represents a GovalCert. */
+    class GovalCert {
+
+        /**
+         * Constructs a new GovalCert.
+         * @param [properties] Properties to set
+         */
+        private constructor(properties?: api.IGovalCert);
+
+        /** GovalCert iat. */
+        public iat?: (google.protobuf.Timestamp|null);
+
+        /** GovalCert exp. */
+        public exp?: (google.protobuf.Timestamp|null);
+
+        /** GovalCert claims. */
+        public claims: api.CertificateClaim[];
+
+        /** GovalCert publicKey. */
+        public publicKey: string;
+
+        /**
+         * Creates a new GovalCert instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns GovalCert instance
+         */
+        public static create(properties?: api.IGovalCert): api.GovalCert;
+
+        /**
+         * Encodes the specified GovalCert message. Does not implicitly {@link api.GovalCert.verify|verify} messages.
+         * @param message GovalCert message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: api.GovalCert, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified GovalCert message, length delimited. Does not implicitly {@link api.GovalCert.verify|verify} messages.
+         * @param message GovalCert message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: api.GovalCert, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a GovalCert message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns GovalCert
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): api.GovalCert;
+
+        /**
+         * Decodes a GovalCert message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns GovalCert
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): api.GovalCert;
+
+        /**
+         * Verifies a GovalCert message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a GovalCert message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns GovalCert
+         */
+        public static fromObject(object: { [k: string]: any }): api.GovalCert;
+
+        /**
+         * Creates a plain object from a GovalCert message. Also converts values to other types if specified.
+         * @param message GovalCert
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: api.GovalCert, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this GovalCert to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of a GovalToken. */
+    interface IGovalToken {
+
+        /** GovalToken iat */
+        iat?: (google.protobuf.Timestamp|google.protobuf.ITimestamp|null);
+
+        /** GovalToken exp */
+        exp?: (google.protobuf.Timestamp|google.protobuf.ITimestamp|null);
+
+        /** GovalToken replid */
+        replid?: (string|null);
+
+        /** GovalToken replToken */
+        replToken?: (api.ReplToken|api.IReplToken|null);
+    }
+
+    /** Represents a GovalToken. */
+    class GovalToken {
+
+        /**
+         * Constructs a new GovalToken.
+         * @param [properties] Properties to set
+         */
+        private constructor(properties?: api.IGovalToken);
+
+        /** GovalToken iat. */
+        public iat?: (google.protobuf.Timestamp|null);
+
+        /** GovalToken exp. */
+        public exp?: (google.protobuf.Timestamp|null);
+
+        /** GovalToken replid. */
+        public replid: string;
+
+        /** GovalToken replToken. */
+        public replToken?: (api.ReplToken|null);
+
+        /** GovalToken Token. */
+        public Token?: "replToken";
+
+        /**
+         * Creates a new GovalToken instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns GovalToken instance
+         */
+        public static create(properties?: api.IGovalToken): api.GovalToken;
+
+        /**
+         * Encodes the specified GovalToken message. Does not implicitly {@link api.GovalToken.verify|verify} messages.
+         * @param message GovalToken message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: api.GovalToken, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified GovalToken message, length delimited. Does not implicitly {@link api.GovalToken.verify|verify} messages.
+         * @param message GovalToken message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: api.GovalToken, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a GovalToken message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns GovalToken
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): api.GovalToken;
+
+        /**
+         * Decodes a GovalToken message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns GovalToken
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): api.GovalToken;
+
+        /**
+         * Verifies a GovalToken message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a GovalToken message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns GovalToken
+         */
+        public static fromObject(object: { [k: string]: any }): api.GovalToken;
+
+        /**
+         * Creates a plain object from a GovalToken message. Also converts values to other types if specified.
+         * @param message GovalToken
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: api.GovalToken, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this GovalToken to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };

--- a/lib/index.js
+++ b/lib/index.js
@@ -34236,192 +34236,6 @@
             return ReplToken;
         })();
     
-        api.GovalTokenMetadata = (function() {
-    
-            /**
-             * Properties of a GovalTokenMetadata.
-             * @memberof api
-             * @interface IGovalTokenMetadata
-             * @property {string|null} [keyId] GovalTokenMetadata keyId
-             */
-    
-            /**
-             * Constructs a new GovalTokenMetadata.
-             * @memberof api
-             * @classdesc Represents a GovalTokenMetadata.
-             * @constructor
-             * @param {api.IGovalTokenMetadata=} [properties] Properties to set
-             */
-            function GovalTokenMetadata(properties) {
-                if (properties)
-                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
-    
-            /**
-             * GovalTokenMetadata keyId.
-             * @member {string} keyId
-             * @memberof api.GovalTokenMetadata
-             * @instance
-             */
-            GovalTokenMetadata.prototype.keyId = "";
-    
-            /**
-             * Creates a new GovalTokenMetadata instance using the specified properties.
-             * @function create
-             * @memberof api.GovalTokenMetadata
-             * @static
-             * @param {api.IGovalTokenMetadata=} [properties] Properties to set
-             * @returns {api.GovalTokenMetadata} GovalTokenMetadata instance
-             */
-            GovalTokenMetadata.create = function create(properties) {
-                return GovalTokenMetadata.fromObject(properties);
-            };
-    
-            /**
-             * Encodes the specified GovalTokenMetadata message. Does not implicitly {@link api.GovalTokenMetadata.verify|verify} messages.
-             * @function encode
-             * @memberof api.GovalTokenMetadata
-             * @static
-             * @param {api.GovalTokenMetadata} message GovalTokenMetadata message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            GovalTokenMetadata.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.keyId != null && Object.hasOwnProperty.call(message, "keyId"))
-                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.keyId);
-                return writer;
-            };
-    
-            /**
-             * Encodes the specified GovalTokenMetadata message, length delimited. Does not implicitly {@link api.GovalTokenMetadata.verify|verify} messages.
-             * @function encodeDelimited
-             * @memberof api.GovalTokenMetadata
-             * @static
-             * @param {api.GovalTokenMetadata} message GovalTokenMetadata message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            GovalTokenMetadata.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
-    
-            /**
-             * Decodes a GovalTokenMetadata message from the specified reader or buffer.
-             * @function decode
-             * @memberof api.GovalTokenMetadata
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @param {number} [length] Message length if known beforehand
-             * @returns {api.GovalTokenMetadata} GovalTokenMetadata
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            GovalTokenMetadata.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.api.GovalTokenMetadata();
-                while (reader.pos < end) {
-                    var tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        message.keyId = reader.string();
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                return message;
-            };
-    
-            /**
-             * Decodes a GovalTokenMetadata message from the specified reader or buffer, length delimited.
-             * @function decodeDelimited
-             * @memberof api.GovalTokenMetadata
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {api.GovalTokenMetadata} GovalTokenMetadata
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            GovalTokenMetadata.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
-    
-            /**
-             * Verifies a GovalTokenMetadata message.
-             * @function verify
-             * @memberof api.GovalTokenMetadata
-             * @static
-             * @param {Object.<string,*>} message Plain object to verify
-             * @returns {string|null} `null` if valid, otherwise the reason why it is not
-             */
-            GovalTokenMetadata.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (message.keyId != null && message.hasOwnProperty("keyId"))
-                    if (!$util.isString(message.keyId))
-                        return "keyId: string expected";
-                return null;
-            };
-    
-            /**
-             * Creates a GovalTokenMetadata message from a plain object. Also converts values to their respective internal types.
-             * @function fromObject
-             * @memberof api.GovalTokenMetadata
-             * @static
-             * @param {Object.<string,*>} object Plain object
-             * @returns {api.GovalTokenMetadata} GovalTokenMetadata
-             */
-            GovalTokenMetadata.fromObject = function fromObject(object) {
-                if (object instanceof $root.api.GovalTokenMetadata)
-                    return object;
-                var message = new $root.api.GovalTokenMetadata();
-                if (object.keyId != null)
-                    message.keyId = String(object.keyId);
-                return message;
-            };
-    
-            /**
-             * Creates a plain object from a GovalTokenMetadata message. Also converts values to other types if specified.
-             * @function toObject
-             * @memberof api.GovalTokenMetadata
-             * @static
-             * @param {api.GovalTokenMetadata} message GovalTokenMetadata
-             * @param {$protobuf.IConversionOptions} [options] Conversion options
-             * @returns {Object.<string,*>} Plain object
-             */
-            GovalTokenMetadata.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                var object = {};
-                if (options.defaults)
-                    object.keyId = "";
-                if (message.keyId != null && message.hasOwnProperty("keyId"))
-                    object.keyId = message.keyId;
-                return object;
-            };
-    
-            /**
-             * Converts this GovalTokenMetadata to JSON.
-             * @function toJSON
-             * @memberof api.GovalTokenMetadata
-             * @instance
-             * @returns {Object.<string,*>} JSON object
-             */
-            GovalTokenMetadata.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
-    
-            return GovalTokenMetadata;
-        })();
-    
         api.TLSCertificate = (function() {
     
             /**
@@ -35904,6 +35718,1148 @@
             };
     
             return EvictReplResponse;
+        })();
+    
+        /**
+         * TokenVersion enum.
+         * @name api.TokenVersion
+         * @enum {number}
+         * @property {number} BARE_REPL_TOKEN=0 BARE_REPL_TOKEN value
+         * @property {number} TYPE_AWARE_TOKEN=1 TYPE_AWARE_TOKEN value
+         */
+        api.TokenVersion = (function() {
+            var valuesById = {}, values = Object.create(valuesById);
+            values[valuesById[0] = "BARE_REPL_TOKEN"] = 0;
+            values[valuesById[1] = "TYPE_AWARE_TOKEN"] = 1;
+            return values;
+        })();
+    
+        api.GovalSigningAuthority = (function() {
+    
+            /**
+             * Properties of a GovalSigningAuthority.
+             * @memberof api
+             * @interface IGovalSigningAuthority
+             * @property {string|null} [keyId] GovalSigningAuthority keyId
+             * @property {string|null} [signedCert] GovalSigningAuthority signedCert
+             * @property {api.TokenVersion|null} [version] GovalSigningAuthority version
+             */
+    
+            /**
+             * Constructs a new GovalSigningAuthority.
+             * @memberof api
+             * @classdesc Represents a GovalSigningAuthority.
+             * @constructor
+             * @param {api.IGovalSigningAuthority=} [properties] Properties to set
+             */
+            function GovalSigningAuthority(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * GovalSigningAuthority keyId.
+             * @member {string} keyId
+             * @memberof api.GovalSigningAuthority
+             * @instance
+             */
+            GovalSigningAuthority.prototype.keyId = "";
+    
+            /**
+             * GovalSigningAuthority signedCert.
+             * @member {string} signedCert
+             * @memberof api.GovalSigningAuthority
+             * @instance
+             */
+            GovalSigningAuthority.prototype.signedCert = "";
+    
+            /**
+             * GovalSigningAuthority version.
+             * @member {api.TokenVersion} version
+             * @memberof api.GovalSigningAuthority
+             * @instance
+             */
+            GovalSigningAuthority.prototype.version = 0;
+    
+            // OneOf field names bound to virtual getters and setters
+            var $oneOfFields;
+    
+            /**
+             * GovalSigningAuthority cert.
+             * @member {"keyId"|"signedCert"|undefined} cert
+             * @memberof api.GovalSigningAuthority
+             * @instance
+             */
+            Object.defineProperty(GovalSigningAuthority.prototype, "cert", {
+                get: $util.oneOfGetter($oneOfFields = ["keyId", "signedCert"]),
+                set: $util.oneOfSetter($oneOfFields)
+            });
+    
+            /**
+             * Creates a new GovalSigningAuthority instance using the specified properties.
+             * @function create
+             * @memberof api.GovalSigningAuthority
+             * @static
+             * @param {api.IGovalSigningAuthority=} [properties] Properties to set
+             * @returns {api.GovalSigningAuthority} GovalSigningAuthority instance
+             */
+            GovalSigningAuthority.create = function create(properties) {
+                return GovalSigningAuthority.fromObject(properties);
+            };
+    
+            /**
+             * Encodes the specified GovalSigningAuthority message. Does not implicitly {@link api.GovalSigningAuthority.verify|verify} messages.
+             * @function encode
+             * @memberof api.GovalSigningAuthority
+             * @static
+             * @param {api.GovalSigningAuthority} message GovalSigningAuthority message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            GovalSigningAuthority.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.keyId != null && Object.hasOwnProperty.call(message, "keyId"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.keyId);
+                if (message.signedCert != null && Object.hasOwnProperty.call(message, "signedCert"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.signedCert);
+                if (message.version != null && Object.hasOwnProperty.call(message, "version"))
+                    writer.uint32(/* id 3, wireType 0 =*/24).int32(message.version);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified GovalSigningAuthority message, length delimited. Does not implicitly {@link api.GovalSigningAuthority.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof api.GovalSigningAuthority
+             * @static
+             * @param {api.GovalSigningAuthority} message GovalSigningAuthority message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            GovalSigningAuthority.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a GovalSigningAuthority message from the specified reader or buffer.
+             * @function decode
+             * @memberof api.GovalSigningAuthority
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {api.GovalSigningAuthority} GovalSigningAuthority
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            GovalSigningAuthority.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.api.GovalSigningAuthority();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.keyId = reader.string();
+                        break;
+                    case 2:
+                        message.signedCert = reader.string();
+                        break;
+                    case 3:
+                        message.version = reader.int32();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a GovalSigningAuthority message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof api.GovalSigningAuthority
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {api.GovalSigningAuthority} GovalSigningAuthority
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            GovalSigningAuthority.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a GovalSigningAuthority message.
+             * @function verify
+             * @memberof api.GovalSigningAuthority
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            GovalSigningAuthority.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                var properties = {};
+                if (message.keyId != null && message.hasOwnProperty("keyId")) {
+                    properties.cert = 1;
+                    if (!$util.isString(message.keyId))
+                        return "keyId: string expected";
+                }
+                if (message.signedCert != null && message.hasOwnProperty("signedCert")) {
+                    if (properties.cert === 1)
+                        return "cert: multiple values";
+                    properties.cert = 1;
+                    if (!$util.isString(message.signedCert))
+                        return "signedCert: string expected";
+                }
+                if (message.version != null && message.hasOwnProperty("version"))
+                    switch (message.version) {
+                    default:
+                        return "version: enum value expected";
+                    case 0:
+                    case 1:
+                        break;
+                    }
+                return null;
+            };
+    
+            /**
+             * Creates a GovalSigningAuthority message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof api.GovalSigningAuthority
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {api.GovalSigningAuthority} GovalSigningAuthority
+             */
+            GovalSigningAuthority.fromObject = function fromObject(object) {
+                if (object instanceof $root.api.GovalSigningAuthority)
+                    return object;
+                var message = new $root.api.GovalSigningAuthority();
+                if (object.keyId != null)
+                    message.keyId = String(object.keyId);
+                if (object.signedCert != null)
+                    message.signedCert = String(object.signedCert);
+                switch (object.version) {
+                case "BARE_REPL_TOKEN":
+                case 0:
+                    message.version = 0;
+                    break;
+                case "TYPE_AWARE_TOKEN":
+                case 1:
+                    message.version = 1;
+                    break;
+                }
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a GovalSigningAuthority message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof api.GovalSigningAuthority
+             * @static
+             * @param {api.GovalSigningAuthority} message GovalSigningAuthority
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            GovalSigningAuthority.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults)
+                    object.version = options.enums === String ? "BARE_REPL_TOKEN" : 0;
+                if (message.keyId != null && message.hasOwnProperty("keyId")) {
+                    object.keyId = message.keyId;
+                    if (options.oneofs)
+                        object.cert = "keyId";
+                }
+                if (message.signedCert != null && message.hasOwnProperty("signedCert")) {
+                    object.signedCert = message.signedCert;
+                    if (options.oneofs)
+                        object.cert = "signedCert";
+                }
+                if (message.version != null && message.hasOwnProperty("version"))
+                    object.version = options.enums === String ? $root.api.TokenVersion[message.version] : message.version;
+                return object;
+            };
+    
+            /**
+             * Converts this GovalSigningAuthority to JSON.
+             * @function toJSON
+             * @memberof api.GovalSigningAuthority
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            GovalSigningAuthority.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return GovalSigningAuthority;
+        })();
+    
+        /**
+         * FlagClaim enum.
+         * @name api.FlagClaim
+         * @enum {number}
+         * @property {number} MINT_GOVAL_TOKEN=0 MINT_GOVAL_TOKEN value
+         * @property {number} SIGN_INTERMEDIATE_CERT=1 SIGN_INTERMEDIATE_CERT value
+         */
+        api.FlagClaim = (function() {
+            var valuesById = {}, values = Object.create(valuesById);
+            values[valuesById[0] = "MINT_GOVAL_TOKEN"] = 0;
+            values[valuesById[1] = "SIGN_INTERMEDIATE_CERT"] = 1;
+            return values;
+        })();
+    
+        api.CertificateClaim = (function() {
+    
+            /**
+             * Properties of a CertificateClaim.
+             * @memberof api
+             * @interface ICertificateClaim
+             * @property {string|null} [replid] CertificateClaim replid
+             * @property {string|null} [user] CertificateClaim user
+             * @property {api.FlagClaim|null} [flag] CertificateClaim flag
+             */
+    
+            /**
+             * Constructs a new CertificateClaim.
+             * @memberof api
+             * @classdesc Represents a CertificateClaim.
+             * @constructor
+             * @param {api.ICertificateClaim=} [properties] Properties to set
+             */
+            function CertificateClaim(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * CertificateClaim replid.
+             * @member {string} replid
+             * @memberof api.CertificateClaim
+             * @instance
+             */
+            CertificateClaim.prototype.replid = "";
+    
+            /**
+             * CertificateClaim user.
+             * @member {string} user
+             * @memberof api.CertificateClaim
+             * @instance
+             */
+            CertificateClaim.prototype.user = "";
+    
+            /**
+             * CertificateClaim flag.
+             * @member {api.FlagClaim} flag
+             * @memberof api.CertificateClaim
+             * @instance
+             */
+            CertificateClaim.prototype.flag = 0;
+    
+            // OneOf field names bound to virtual getters and setters
+            var $oneOfFields;
+    
+            /**
+             * CertificateClaim claim.
+             * @member {"replid"|"user"|"flag"|undefined} claim
+             * @memberof api.CertificateClaim
+             * @instance
+             */
+            Object.defineProperty(CertificateClaim.prototype, "claim", {
+                get: $util.oneOfGetter($oneOfFields = ["replid", "user", "flag"]),
+                set: $util.oneOfSetter($oneOfFields)
+            });
+    
+            /**
+             * Creates a new CertificateClaim instance using the specified properties.
+             * @function create
+             * @memberof api.CertificateClaim
+             * @static
+             * @param {api.ICertificateClaim=} [properties] Properties to set
+             * @returns {api.CertificateClaim} CertificateClaim instance
+             */
+            CertificateClaim.create = function create(properties) {
+                return CertificateClaim.fromObject(properties);
+            };
+    
+            /**
+             * Encodes the specified CertificateClaim message. Does not implicitly {@link api.CertificateClaim.verify|verify} messages.
+             * @function encode
+             * @memberof api.CertificateClaim
+             * @static
+             * @param {api.CertificateClaim} message CertificateClaim message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            CertificateClaim.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.replid != null && Object.hasOwnProperty.call(message, "replid"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.replid);
+                if (message.user != null && Object.hasOwnProperty.call(message, "user"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.user);
+                if (message.flag != null && Object.hasOwnProperty.call(message, "flag"))
+                    writer.uint32(/* id 3, wireType 0 =*/24).int32(message.flag);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified CertificateClaim message, length delimited. Does not implicitly {@link api.CertificateClaim.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof api.CertificateClaim
+             * @static
+             * @param {api.CertificateClaim} message CertificateClaim message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            CertificateClaim.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a CertificateClaim message from the specified reader or buffer.
+             * @function decode
+             * @memberof api.CertificateClaim
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {api.CertificateClaim} CertificateClaim
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            CertificateClaim.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.api.CertificateClaim();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.replid = reader.string();
+                        break;
+                    case 2:
+                        message.user = reader.string();
+                        break;
+                    case 3:
+                        message.flag = reader.int32();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a CertificateClaim message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof api.CertificateClaim
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {api.CertificateClaim} CertificateClaim
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            CertificateClaim.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a CertificateClaim message.
+             * @function verify
+             * @memberof api.CertificateClaim
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            CertificateClaim.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                var properties = {};
+                if (message.replid != null && message.hasOwnProperty("replid")) {
+                    properties.claim = 1;
+                    if (!$util.isString(message.replid))
+                        return "replid: string expected";
+                }
+                if (message.user != null && message.hasOwnProperty("user")) {
+                    if (properties.claim === 1)
+                        return "claim: multiple values";
+                    properties.claim = 1;
+                    if (!$util.isString(message.user))
+                        return "user: string expected";
+                }
+                if (message.flag != null && message.hasOwnProperty("flag")) {
+                    if (properties.claim === 1)
+                        return "claim: multiple values";
+                    properties.claim = 1;
+                    switch (message.flag) {
+                    default:
+                        return "flag: enum value expected";
+                    case 0:
+                    case 1:
+                        break;
+                    }
+                }
+                return null;
+            };
+    
+            /**
+             * Creates a CertificateClaim message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof api.CertificateClaim
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {api.CertificateClaim} CertificateClaim
+             */
+            CertificateClaim.fromObject = function fromObject(object) {
+                if (object instanceof $root.api.CertificateClaim)
+                    return object;
+                var message = new $root.api.CertificateClaim();
+                if (object.replid != null)
+                    message.replid = String(object.replid);
+                if (object.user != null)
+                    message.user = String(object.user);
+                switch (object.flag) {
+                case "MINT_GOVAL_TOKEN":
+                case 0:
+                    message.flag = 0;
+                    break;
+                case "SIGN_INTERMEDIATE_CERT":
+                case 1:
+                    message.flag = 1;
+                    break;
+                }
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a CertificateClaim message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof api.CertificateClaim
+             * @static
+             * @param {api.CertificateClaim} message CertificateClaim
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            CertificateClaim.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (message.replid != null && message.hasOwnProperty("replid")) {
+                    object.replid = message.replid;
+                    if (options.oneofs)
+                        object.claim = "replid";
+                }
+                if (message.user != null && message.hasOwnProperty("user")) {
+                    object.user = message.user;
+                    if (options.oneofs)
+                        object.claim = "user";
+                }
+                if (message.flag != null && message.hasOwnProperty("flag")) {
+                    object.flag = options.enums === String ? $root.api.FlagClaim[message.flag] : message.flag;
+                    if (options.oneofs)
+                        object.claim = "flag";
+                }
+                return object;
+            };
+    
+            /**
+             * Converts this CertificateClaim to JSON.
+             * @function toJSON
+             * @memberof api.CertificateClaim
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            CertificateClaim.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return CertificateClaim;
+        })();
+    
+        api.GovalCert = (function() {
+    
+            /**
+             * Properties of a GovalCert.
+             * @memberof api
+             * @interface IGovalCert
+             * @property {google.protobuf.Timestamp|google.protobuf.ITimestamp|null} [iat] GovalCert iat
+             * @property {google.protobuf.Timestamp|google.protobuf.ITimestamp|null} [exp] GovalCert exp
+             * @property {Array.<api.CertificateClaim|api.ICertificateClaim>|null} [claims] GovalCert claims
+             * @property {string|null} [publicKey] GovalCert publicKey
+             */
+    
+            /**
+             * Constructs a new GovalCert.
+             * @memberof api
+             * @classdesc Represents a GovalCert.
+             * @constructor
+             * @param {api.IGovalCert=} [properties] Properties to set
+             */
+            function GovalCert(properties) {
+                this.claims = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * GovalCert iat.
+             * @member {google.protobuf.Timestamp|null|undefined} iat
+             * @memberof api.GovalCert
+             * @instance
+             */
+            GovalCert.prototype.iat = null;
+    
+            /**
+             * GovalCert exp.
+             * @member {google.protobuf.Timestamp|null|undefined} exp
+             * @memberof api.GovalCert
+             * @instance
+             */
+            GovalCert.prototype.exp = null;
+    
+            /**
+             * GovalCert claims.
+             * @member {Array.<api.CertificateClaim>} claims
+             * @memberof api.GovalCert
+             * @instance
+             */
+            GovalCert.prototype.claims = $util.emptyArray;
+    
+            /**
+             * GovalCert publicKey.
+             * @member {string} publicKey
+             * @memberof api.GovalCert
+             * @instance
+             */
+            GovalCert.prototype.publicKey = "";
+    
+            /**
+             * Creates a new GovalCert instance using the specified properties.
+             * @function create
+             * @memberof api.GovalCert
+             * @static
+             * @param {api.IGovalCert=} [properties] Properties to set
+             * @returns {api.GovalCert} GovalCert instance
+             */
+            GovalCert.create = function create(properties) {
+                return GovalCert.fromObject(properties);
+            };
+    
+            /**
+             * Encodes the specified GovalCert message. Does not implicitly {@link api.GovalCert.verify|verify} messages.
+             * @function encode
+             * @memberof api.GovalCert
+             * @static
+             * @param {api.GovalCert} message GovalCert message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            GovalCert.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.iat != null && Object.hasOwnProperty.call(message, "iat"))
+                    $root.google.protobuf.Timestamp.encode(message.iat, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                if (message.exp != null && Object.hasOwnProperty.call(message, "exp"))
+                    $root.google.protobuf.Timestamp.encode(message.exp, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                if (message.claims != null && message.claims.length)
+                    for (var i = 0; i < message.claims.length; ++i)
+                        $root.api.CertificateClaim.encode(message.claims[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                if (message.publicKey != null && Object.hasOwnProperty.call(message, "publicKey"))
+                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.publicKey);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified GovalCert message, length delimited. Does not implicitly {@link api.GovalCert.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof api.GovalCert
+             * @static
+             * @param {api.GovalCert} message GovalCert message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            GovalCert.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a GovalCert message from the specified reader or buffer.
+             * @function decode
+             * @memberof api.GovalCert
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {api.GovalCert} GovalCert
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            GovalCert.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.api.GovalCert();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.iat = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                        break;
+                    case 2:
+                        message.exp = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                        break;
+                    case 3:
+                        if (!(message.claims && message.claims.length))
+                            message.claims = [];
+                        message.claims.push($root.api.CertificateClaim.decode(reader, reader.uint32()));
+                        break;
+                    case 4:
+                        message.publicKey = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a GovalCert message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof api.GovalCert
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {api.GovalCert} GovalCert
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            GovalCert.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a GovalCert message.
+             * @function verify
+             * @memberof api.GovalCert
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            GovalCert.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.iat != null && message.hasOwnProperty("iat")) {
+                    var error = $root.google.protobuf.Timestamp.verify(message.iat);
+                    if (error)
+                        return "iat." + error;
+                }
+                if (message.exp != null && message.hasOwnProperty("exp")) {
+                    var error = $root.google.protobuf.Timestamp.verify(message.exp);
+                    if (error)
+                        return "exp." + error;
+                }
+                if (message.claims != null && message.hasOwnProperty("claims")) {
+                    if (!Array.isArray(message.claims))
+                        return "claims: array expected";
+                    for (var i = 0; i < message.claims.length; ++i) {
+                        var error = $root.api.CertificateClaim.verify(message.claims[i]);
+                        if (error)
+                            return "claims." + error;
+                    }
+                }
+                if (message.publicKey != null && message.hasOwnProperty("publicKey"))
+                    if (!$util.isString(message.publicKey))
+                        return "publicKey: string expected";
+                return null;
+            };
+    
+            /**
+             * Creates a GovalCert message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof api.GovalCert
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {api.GovalCert} GovalCert
+             */
+            GovalCert.fromObject = function fromObject(object) {
+                if (object instanceof $root.api.GovalCert)
+                    return object;
+                var message = new $root.api.GovalCert();
+                if (object.iat != null) {
+                    if (typeof object.iat !== "object")
+                        throw TypeError(".api.GovalCert.iat: object expected");
+                    message.iat = $root.google.protobuf.Timestamp.fromObject(object.iat);
+                }
+                if (object.exp != null) {
+                    if (typeof object.exp !== "object")
+                        throw TypeError(".api.GovalCert.exp: object expected");
+                    message.exp = $root.google.protobuf.Timestamp.fromObject(object.exp);
+                }
+                if (object.claims) {
+                    if (!Array.isArray(object.claims))
+                        throw TypeError(".api.GovalCert.claims: array expected");
+                    message.claims = [];
+                    for (var i = 0; i < object.claims.length; ++i) {
+                        if (typeof object.claims[i] !== "object")
+                            throw TypeError(".api.GovalCert.claims: object expected");
+                        message.claims[i] = $root.api.CertificateClaim.fromObject(object.claims[i]);
+                    }
+                }
+                if (object.publicKey != null)
+                    message.publicKey = String(object.publicKey);
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a GovalCert message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof api.GovalCert
+             * @static
+             * @param {api.GovalCert} message GovalCert
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            GovalCert.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.claims = [];
+                if (options.defaults) {
+                    object.iat = null;
+                    object.exp = null;
+                    object.publicKey = "";
+                }
+                if (message.iat != null && message.hasOwnProperty("iat"))
+                    object.iat = $root.google.protobuf.Timestamp.toObject(message.iat, options);
+                if (message.exp != null && message.hasOwnProperty("exp"))
+                    object.exp = $root.google.protobuf.Timestamp.toObject(message.exp, options);
+                if (message.claims && message.claims.length) {
+                    object.claims = [];
+                    for (var j = 0; j < message.claims.length; ++j)
+                        object.claims[j] = $root.api.CertificateClaim.toObject(message.claims[j], options);
+                }
+                if (message.publicKey != null && message.hasOwnProperty("publicKey"))
+                    object.publicKey = message.publicKey;
+                return object;
+            };
+    
+            /**
+             * Converts this GovalCert to JSON.
+             * @function toJSON
+             * @memberof api.GovalCert
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            GovalCert.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return GovalCert;
+        })();
+    
+        api.GovalToken = (function() {
+    
+            /**
+             * Properties of a GovalToken.
+             * @memberof api
+             * @interface IGovalToken
+             * @property {google.protobuf.Timestamp|google.protobuf.ITimestamp|null} [iat] GovalToken iat
+             * @property {google.protobuf.Timestamp|google.protobuf.ITimestamp|null} [exp] GovalToken exp
+             * @property {string|null} [replid] GovalToken replid
+             * @property {api.ReplToken|api.IReplToken|null} [replToken] GovalToken replToken
+             */
+    
+            /**
+             * Constructs a new GovalToken.
+             * @memberof api
+             * @classdesc Represents a GovalToken.
+             * @constructor
+             * @param {api.IGovalToken=} [properties] Properties to set
+             */
+            function GovalToken(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * GovalToken iat.
+             * @member {google.protobuf.Timestamp|null|undefined} iat
+             * @memberof api.GovalToken
+             * @instance
+             */
+            GovalToken.prototype.iat = null;
+    
+            /**
+             * GovalToken exp.
+             * @member {google.protobuf.Timestamp|null|undefined} exp
+             * @memberof api.GovalToken
+             * @instance
+             */
+            GovalToken.prototype.exp = null;
+    
+            /**
+             * GovalToken replid.
+             * @member {string} replid
+             * @memberof api.GovalToken
+             * @instance
+             */
+            GovalToken.prototype.replid = "";
+    
+            /**
+             * GovalToken replToken.
+             * @member {api.ReplToken|null|undefined} replToken
+             * @memberof api.GovalToken
+             * @instance
+             */
+            GovalToken.prototype.replToken = null;
+    
+            // OneOf field names bound to virtual getters and setters
+            var $oneOfFields;
+    
+            /**
+             * GovalToken Token.
+             * @member {"replToken"|undefined} Token
+             * @memberof api.GovalToken
+             * @instance
+             */
+            Object.defineProperty(GovalToken.prototype, "Token", {
+                get: $util.oneOfGetter($oneOfFields = ["replToken"]),
+                set: $util.oneOfSetter($oneOfFields)
+            });
+    
+            /**
+             * Creates a new GovalToken instance using the specified properties.
+             * @function create
+             * @memberof api.GovalToken
+             * @static
+             * @param {api.IGovalToken=} [properties] Properties to set
+             * @returns {api.GovalToken} GovalToken instance
+             */
+            GovalToken.create = function create(properties) {
+                return GovalToken.fromObject(properties);
+            };
+    
+            /**
+             * Encodes the specified GovalToken message. Does not implicitly {@link api.GovalToken.verify|verify} messages.
+             * @function encode
+             * @memberof api.GovalToken
+             * @static
+             * @param {api.GovalToken} message GovalToken message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            GovalToken.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.iat != null && Object.hasOwnProperty.call(message, "iat"))
+                    $root.google.protobuf.Timestamp.encode(message.iat, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                if (message.exp != null && Object.hasOwnProperty.call(message, "exp"))
+                    $root.google.protobuf.Timestamp.encode(message.exp, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                if (message.replid != null && Object.hasOwnProperty.call(message, "replid"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.replid);
+                if (message.replToken != null && Object.hasOwnProperty.call(message, "replToken"))
+                    $root.api.ReplToken.encode(message.replToken, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified GovalToken message, length delimited. Does not implicitly {@link api.GovalToken.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof api.GovalToken
+             * @static
+             * @param {api.GovalToken} message GovalToken message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            GovalToken.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a GovalToken message from the specified reader or buffer.
+             * @function decode
+             * @memberof api.GovalToken
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {api.GovalToken} GovalToken
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            GovalToken.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.api.GovalToken();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.iat = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                        break;
+                    case 2:
+                        message.exp = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                        break;
+                    case 3:
+                        message.replid = reader.string();
+                        break;
+                    case 4:
+                        message.replToken = $root.api.ReplToken.decode(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a GovalToken message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof api.GovalToken
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {api.GovalToken} GovalToken
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            GovalToken.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a GovalToken message.
+             * @function verify
+             * @memberof api.GovalToken
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            GovalToken.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                var properties = {};
+                if (message.iat != null && message.hasOwnProperty("iat")) {
+                    var error = $root.google.protobuf.Timestamp.verify(message.iat);
+                    if (error)
+                        return "iat." + error;
+                }
+                if (message.exp != null && message.hasOwnProperty("exp")) {
+                    var error = $root.google.protobuf.Timestamp.verify(message.exp);
+                    if (error)
+                        return "exp." + error;
+                }
+                if (message.replid != null && message.hasOwnProperty("replid"))
+                    if (!$util.isString(message.replid))
+                        return "replid: string expected";
+                if (message.replToken != null && message.hasOwnProperty("replToken")) {
+                    properties.Token = 1;
+                    {
+                        var error = $root.api.ReplToken.verify(message.replToken);
+                        if (error)
+                            return "replToken." + error;
+                    }
+                }
+                return null;
+            };
+    
+            /**
+             * Creates a GovalToken message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof api.GovalToken
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {api.GovalToken} GovalToken
+             */
+            GovalToken.fromObject = function fromObject(object) {
+                if (object instanceof $root.api.GovalToken)
+                    return object;
+                var message = new $root.api.GovalToken();
+                if (object.iat != null) {
+                    if (typeof object.iat !== "object")
+                        throw TypeError(".api.GovalToken.iat: object expected");
+                    message.iat = $root.google.protobuf.Timestamp.fromObject(object.iat);
+                }
+                if (object.exp != null) {
+                    if (typeof object.exp !== "object")
+                        throw TypeError(".api.GovalToken.exp: object expected");
+                    message.exp = $root.google.protobuf.Timestamp.fromObject(object.exp);
+                }
+                if (object.replid != null)
+                    message.replid = String(object.replid);
+                if (object.replToken != null) {
+                    if (typeof object.replToken !== "object")
+                        throw TypeError(".api.GovalToken.replToken: object expected");
+                    message.replToken = $root.api.ReplToken.fromObject(object.replToken);
+                }
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a GovalToken message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof api.GovalToken
+             * @static
+             * @param {api.GovalToken} message GovalToken
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            GovalToken.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.iat = null;
+                    object.exp = null;
+                    object.replid = "";
+                }
+                if (message.iat != null && message.hasOwnProperty("iat"))
+                    object.iat = $root.google.protobuf.Timestamp.toObject(message.iat, options);
+                if (message.exp != null && message.hasOwnProperty("exp"))
+                    object.exp = $root.google.protobuf.Timestamp.toObject(message.exp, options);
+                if (message.replid != null && message.hasOwnProperty("replid"))
+                    object.replid = message.replid;
+                if (message.replToken != null && message.hasOwnProperty("replToken")) {
+                    object.replToken = $root.api.ReplToken.toObject(message.replToken, options);
+                    if (options.oneofs)
+                        object.Token = "replToken";
+                }
+                return object;
+            };
+    
+            /**
+             * Converts this GovalToken to JSON.
+             * @function toJSON
+             * @memberof api.GovalToken
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            GovalToken.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return GovalToken;
         })();
     
         return api;

--- a/lib/index.js.flow
+++ b/lib/index.js.flow
@@ -11,6 +11,8 @@ export var api = npm$namespace$api;
 declare var npm$namespace$api: {|
   FileAuthMethod: typeof api$FileAuthMethod,
   State: typeof api$State,
+  TokenVersion: typeof api$TokenVersion,
+  FlagClaim: typeof api$FlagClaim,
   ICommand: Class<api$ICommand>,
   IAudio: Class<api$IAudio>,
   IAudio2: Class<api$IAudio2>,
@@ -141,13 +143,16 @@ declare var npm$namespace$api: {|
   IResourceLimits: Class<api$IResourceLimits>,
   IPermissions: Class<api$IPermissions>,
   IReplToken: Class<api$IReplToken>,
-  IGovalTokenMetadata: Class<api$IGovalTokenMetadata>,
   ITLSCertificate: Class<api$ITLSCertificate>,
   IReplTransfer: Class<api$IReplTransfer>,
   IAllowReplRequest: Class<api$IAllowReplRequest>,
   IClusterMetadata: Class<api$IClusterMetadata>,
   IEvictReplRequest: Class<api$IEvictReplRequest>,
   IEvictReplResponse: Class<api$IEvictReplResponse>,
+  IGovalSigningAuthority: Class<api$IGovalSigningAuthority>,
+  ICertificateClaim: Class<api$ICertificateClaim>,
+  IGovalCert: Class<api$IGovalCert>,
+  IGovalToken: Class<api$IGovalToken>,
   Command: typeof api$Command,
   Audio: typeof api$Audio,
   Audio2: typeof api$Audio2,
@@ -278,13 +283,16 @@ declare var npm$namespace$api: {|
   ResourceLimits: typeof api$ResourceLimits,
   Permissions: typeof api$Permissions,
   ReplToken: typeof api$ReplToken,
-  GovalTokenMetadata: typeof api$GovalTokenMetadata,
   TLSCertificate: typeof api$TLSCertificate,
   ReplTransfer: typeof api$ReplTransfer,
   AllowReplRequest: typeof api$AllowReplRequest,
   ClusterMetadata: typeof api$ClusterMetadata,
   EvictReplRequest: typeof api$EvictReplRequest,
   EvictReplResponse: typeof api$EvictReplResponse,
+  GovalSigningAuthority: typeof api$GovalSigningAuthority,
+  CertificateClaim: typeof api$CertificateClaim,
+  GovalCert: typeof api$GovalCert,
+  GovalToken: typeof api$GovalToken,
 |};
 
 /**
@@ -19010,124 +19018,6 @@ declare class api$ReplToken$Presenced {
 }
 
 /**
- * Properties of a GovalTokenMetadata.
- */
-declare type api$IGovalTokenMetadata = {|
-  /**
-   * GovalTokenMetadata keyId
-   */
-  keyId?: string | null,
-|};
-
-/**
- * Represents a GovalTokenMetadata.
- */
-declare class api$GovalTokenMetadata {
-  /**
-   * Constructs a new GovalTokenMetadata.
-   * @param [properties] Properties to set
-   */
-  constructor(properties?: api$IGovalTokenMetadata): this;
-
-  /**
-   * GovalTokenMetadata keyId.
-   */
-  keyId: string;
-
-  /**
-   * Creates a new GovalTokenMetadata instance using the specified properties.
-   * @param [properties] Properties to set
-   * @returns GovalTokenMetadata instance
-   */
-  static create(properties?: api$IGovalTokenMetadata): api$GovalTokenMetadata;
-
-  /**
-   * Encodes the specified GovalTokenMetadata message. Does not implicitly {@link api.GovalTokenMetadata.verify|verify} messages.
-   * @param message GovalTokenMetadata message or plain object to encode
-   * @param [writer] Writer to encode to
-   * @returns Writer
-   */
-  static encode(
-    message: api$GovalTokenMetadata,
-    writer?: $protobuf.Writer
-  ): $protobuf.Writer;
-
-  /**
-   * Encodes the specified GovalTokenMetadata message, length delimited. Does not implicitly {@link api.GovalTokenMetadata.verify|verify} messages.
-   * @param message GovalTokenMetadata message or plain object to encode
-   * @param [writer] Writer to encode to
-   * @returns Writer
-   */
-  static encodeDelimited(
-    message: api$GovalTokenMetadata,
-    writer?: $protobuf.Writer
-  ): $protobuf.Writer;
-
-  /**
-   * Decodes a GovalTokenMetadata message from the specified reader or buffer.
-   * @param reader Reader or buffer to decode from
-   * @param [length] Message length if known beforehand
-   * @returns GovalTokenMetadata
-   * @throws {Error} If the payload is not a reader or valid buffer
-   * @throws {$protobuf.util.ProtocolError} If required fields are missing
-   */
-  static decode(
-    reader: $protobuf.Reader | Uint8Array,
-    length?: number
-  ): api$GovalTokenMetadata;
-
-  /**
-   * Decodes a GovalTokenMetadata message from the specified reader or buffer, length delimited.
-   * @param reader Reader or buffer to decode from
-   * @returns GovalTokenMetadata
-   * @throws {Error} If the payload is not a reader or valid buffer
-   * @throws {$protobuf.util.ProtocolError} If required fields are missing
-   */
-  static decodeDelimited(
-    reader: $protobuf.Reader | Uint8Array
-  ): api$GovalTokenMetadata;
-
-  /**
-   * Verifies a GovalTokenMetadata message.
-   * @param message Plain object to verify
-   * @returns `null` if valid, otherwise the reason why it is not
-   */
-  static verify(message: {
-    [k: string]: any,
-  }): string | null;
-
-  /**
-   * Creates a GovalTokenMetadata message from a plain object. Also converts values to their respective internal types.
-   * @param object Plain object
-   * @returns GovalTokenMetadata
-   */
-  static fromObject(object: {
-    [k: string]: any,
-  }): api$GovalTokenMetadata;
-
-  /**
-   * Creates a plain object from a GovalTokenMetadata message. Also converts values to other types if specified.
-   * @param message GovalTokenMetadata
-   * @param [options] Conversion options
-   * @returns Plain object
-   */
-  static toObject(
-    message: api$GovalTokenMetadata,
-    options?: $protobuf.IConversionOptions
-  ): {
-    [k: string]: any,
-  };
-
-  /**
-   * Converts this GovalTokenMetadata to JSON.
-   * @returns JSON object
-   */
-  toJSON(): {
-    [k: string]: any,
-  };
-}
-
-/**
  * Properties of a TLSCertificate.
  */
 declare type api$ITLSCertificate = {|
@@ -19958,6 +19848,609 @@ declare class api$EvictReplResponse {
 
   /**
    * Converts this EvictReplResponse to JSON.
+   * @returns JSON object
+   */
+  toJSON(): {
+    [k: string]: any,
+  };
+}
+
+/**
+ * TokenVersion enum.
+ */
+
+declare var api$TokenVersion: {|
+  +BARE_REPL_TOKEN: 0, // 0
+  +TYPE_AWARE_TOKEN: 1, // 1
+|};
+
+/**
+ * Properties of a GovalSigningAuthority.
+ */
+declare type api$IGovalSigningAuthority = {|
+  /**
+   * GovalSigningAuthority keyId
+   */
+  keyId?: string | null,
+
+  /**
+   * GovalSigningAuthority signedCert
+   */
+  signedCert?: string | null,
+
+  /**
+   * GovalSigningAuthority version
+   */
+  version?: $Values<typeof api$TokenVersion> | null,
+|};
+
+/**
+ * Represents a GovalSigningAuthority.
+ */
+declare class api$GovalSigningAuthority {
+  /**
+   * Constructs a new GovalSigningAuthority.
+   * @param [properties] Properties to set
+   */
+  constructor(properties?: api$IGovalSigningAuthority): this;
+
+  /**
+   * GovalSigningAuthority keyId.
+   */
+  keyId: string;
+
+  /**
+   * GovalSigningAuthority signedCert.
+   */
+  signedCert: string;
+
+  /**
+   * GovalSigningAuthority version.
+   */
+  version: $Values<typeof api$TokenVersion>;
+
+  /**
+   * GovalSigningAuthority cert.
+   */
+  cert?: "keyId" | "signedCert";
+
+  /**
+   * Creates a new GovalSigningAuthority instance using the specified properties.
+   * @param [properties] Properties to set
+   * @returns GovalSigningAuthority instance
+   */
+  static create(
+    properties?: api$IGovalSigningAuthority
+  ): api$GovalSigningAuthority;
+
+  /**
+   * Encodes the specified GovalSigningAuthority message. Does not implicitly {@link api.GovalSigningAuthority.verify|verify} messages.
+   * @param message GovalSigningAuthority message or plain object to encode
+   * @param [writer] Writer to encode to
+   * @returns Writer
+   */
+  static encode(
+    message: api$GovalSigningAuthority,
+    writer?: $protobuf.Writer
+  ): $protobuf.Writer;
+
+  /**
+   * Encodes the specified GovalSigningAuthority message, length delimited. Does not implicitly {@link api.GovalSigningAuthority.verify|verify} messages.
+   * @param message GovalSigningAuthority message or plain object to encode
+   * @param [writer] Writer to encode to
+   * @returns Writer
+   */
+  static encodeDelimited(
+    message: api$GovalSigningAuthority,
+    writer?: $protobuf.Writer
+  ): $protobuf.Writer;
+
+  /**
+   * Decodes a GovalSigningAuthority message from the specified reader or buffer.
+   * @param reader Reader or buffer to decode from
+   * @param [length] Message length if known beforehand
+   * @returns GovalSigningAuthority
+   * @throws {Error} If the payload is not a reader or valid buffer
+   * @throws {$protobuf.util.ProtocolError} If required fields are missing
+   */
+  static decode(
+    reader: $protobuf.Reader | Uint8Array,
+    length?: number
+  ): api$GovalSigningAuthority;
+
+  /**
+   * Decodes a GovalSigningAuthority message from the specified reader or buffer, length delimited.
+   * @param reader Reader or buffer to decode from
+   * @returns GovalSigningAuthority
+   * @throws {Error} If the payload is not a reader or valid buffer
+   * @throws {$protobuf.util.ProtocolError} If required fields are missing
+   */
+  static decodeDelimited(
+    reader: $protobuf.Reader | Uint8Array
+  ): api$GovalSigningAuthority;
+
+  /**
+   * Verifies a GovalSigningAuthority message.
+   * @param message Plain object to verify
+   * @returns `null` if valid, otherwise the reason why it is not
+   */
+  static verify(message: {
+    [k: string]: any,
+  }): string | null;
+
+  /**
+   * Creates a GovalSigningAuthority message from a plain object. Also converts values to their respective internal types.
+   * @param object Plain object
+   * @returns GovalSigningAuthority
+   */
+  static fromObject(object: {
+    [k: string]: any,
+  }): api$GovalSigningAuthority;
+
+  /**
+   * Creates a plain object from a GovalSigningAuthority message. Also converts values to other types if specified.
+   * @param message GovalSigningAuthority
+   * @param [options] Conversion options
+   * @returns Plain object
+   */
+  static toObject(
+    message: api$GovalSigningAuthority,
+    options?: $protobuf.IConversionOptions
+  ): {
+    [k: string]: any,
+  };
+
+  /**
+   * Converts this GovalSigningAuthority to JSON.
+   * @returns JSON object
+   */
+  toJSON(): {
+    [k: string]: any,
+  };
+}
+
+/**
+ * FlagClaim enum.
+ */
+
+declare var api$FlagClaim: {|
+  +MINT_GOVAL_TOKEN: 0, // 0
+  +SIGN_INTERMEDIATE_CERT: 1, // 1
+|};
+
+/**
+ * Properties of a CertificateClaim.
+ */
+declare type api$ICertificateClaim = {|
+  /**
+   * CertificateClaim replid
+   */
+  replid?: string | null,
+
+  /**
+   * CertificateClaim user
+   */
+  user?: string | null,
+
+  /**
+   * CertificateClaim flag
+   */
+  flag?: $Values<typeof api$FlagClaim> | null,
+|};
+
+/**
+ * Represents a CertificateClaim.
+ */
+declare class api$CertificateClaim {
+  /**
+   * Constructs a new CertificateClaim.
+   * @param [properties] Properties to set
+   */
+  constructor(properties?: api$ICertificateClaim): this;
+
+  /**
+   * CertificateClaim replid.
+   */
+  replid: string;
+
+  /**
+   * CertificateClaim user.
+   */
+  user: string;
+
+  /**
+   * CertificateClaim flag.
+   */
+  flag: $Values<typeof api$FlagClaim>;
+
+  /**
+   * CertificateClaim claim.
+   */
+  claim?: "replid" | "user" | "flag";
+
+  /**
+   * Creates a new CertificateClaim instance using the specified properties.
+   * @param [properties] Properties to set
+   * @returns CertificateClaim instance
+   */
+  static create(properties?: api$ICertificateClaim): api$CertificateClaim;
+
+  /**
+   * Encodes the specified CertificateClaim message. Does not implicitly {@link api.CertificateClaim.verify|verify} messages.
+   * @param message CertificateClaim message or plain object to encode
+   * @param [writer] Writer to encode to
+   * @returns Writer
+   */
+  static encode(
+    message: api$CertificateClaim,
+    writer?: $protobuf.Writer
+  ): $protobuf.Writer;
+
+  /**
+   * Encodes the specified CertificateClaim message, length delimited. Does not implicitly {@link api.CertificateClaim.verify|verify} messages.
+   * @param message CertificateClaim message or plain object to encode
+   * @param [writer] Writer to encode to
+   * @returns Writer
+   */
+  static encodeDelimited(
+    message: api$CertificateClaim,
+    writer?: $protobuf.Writer
+  ): $protobuf.Writer;
+
+  /**
+   * Decodes a CertificateClaim message from the specified reader or buffer.
+   * @param reader Reader or buffer to decode from
+   * @param [length] Message length if known beforehand
+   * @returns CertificateClaim
+   * @throws {Error} If the payload is not a reader or valid buffer
+   * @throws {$protobuf.util.ProtocolError} If required fields are missing
+   */
+  static decode(
+    reader: $protobuf.Reader | Uint8Array,
+    length?: number
+  ): api$CertificateClaim;
+
+  /**
+   * Decodes a CertificateClaim message from the specified reader or buffer, length delimited.
+   * @param reader Reader or buffer to decode from
+   * @returns CertificateClaim
+   * @throws {Error} If the payload is not a reader or valid buffer
+   * @throws {$protobuf.util.ProtocolError} If required fields are missing
+   */
+  static decodeDelimited(
+    reader: $protobuf.Reader | Uint8Array
+  ): api$CertificateClaim;
+
+  /**
+   * Verifies a CertificateClaim message.
+   * @param message Plain object to verify
+   * @returns `null` if valid, otherwise the reason why it is not
+   */
+  static verify(message: {
+    [k: string]: any,
+  }): string | null;
+
+  /**
+   * Creates a CertificateClaim message from a plain object. Also converts values to their respective internal types.
+   * @param object Plain object
+   * @returns CertificateClaim
+   */
+  static fromObject(object: {
+    [k: string]: any,
+  }): api$CertificateClaim;
+
+  /**
+   * Creates a plain object from a CertificateClaim message. Also converts values to other types if specified.
+   * @param message CertificateClaim
+   * @param [options] Conversion options
+   * @returns Plain object
+   */
+  static toObject(
+    message: api$CertificateClaim,
+    options?: $protobuf.IConversionOptions
+  ): {
+    [k: string]: any,
+  };
+
+  /**
+   * Converts this CertificateClaim to JSON.
+   * @returns JSON object
+   */
+  toJSON(): {
+    [k: string]: any,
+  };
+}
+
+/**
+ * Properties of a GovalCert.
+ */
+declare type api$IGovalCert = {|
+  /**
+   * GovalCert iat
+   */
+  iat?: google$protobuf$Timestamp | google$protobuf$ITimestamp | null,
+
+  /**
+   * GovalCert exp
+   */
+  exp?: google$protobuf$Timestamp | google$protobuf$ITimestamp | null,
+
+  /**
+   * GovalCert claims
+   */
+  claims?: (api$CertificateClaim | api$ICertificateClaim)[] | null,
+
+  /**
+   * GovalCert publicKey
+   */
+  publicKey?: string | null,
+|};
+
+/**
+ * Represents a GovalCert.
+ */
+declare class api$GovalCert {
+  /**
+   * Constructs a new GovalCert.
+   * @param [properties] Properties to set
+   */
+  constructor(properties?: api$IGovalCert): this;
+
+  /**
+   * GovalCert iat.
+   */
+  iat?: google$protobuf$Timestamp | null;
+
+  /**
+   * GovalCert exp.
+   */
+  exp?: google$protobuf$Timestamp | null;
+
+  /**
+   * GovalCert claims.
+   */
+  claims: api$CertificateClaim[];
+
+  /**
+   * GovalCert publicKey.
+   */
+  publicKey: string;
+
+  /**
+   * Creates a new GovalCert instance using the specified properties.
+   * @param [properties] Properties to set
+   * @returns GovalCert instance
+   */
+  static create(properties?: api$IGovalCert): api$GovalCert;
+
+  /**
+   * Encodes the specified GovalCert message. Does not implicitly {@link api.GovalCert.verify|verify} messages.
+   * @param message GovalCert message or plain object to encode
+   * @param [writer] Writer to encode to
+   * @returns Writer
+   */
+  static encode(
+    message: api$GovalCert,
+    writer?: $protobuf.Writer
+  ): $protobuf.Writer;
+
+  /**
+   * Encodes the specified GovalCert message, length delimited. Does not implicitly {@link api.GovalCert.verify|verify} messages.
+   * @param message GovalCert message or plain object to encode
+   * @param [writer] Writer to encode to
+   * @returns Writer
+   */
+  static encodeDelimited(
+    message: api$GovalCert,
+    writer?: $protobuf.Writer
+  ): $protobuf.Writer;
+
+  /**
+   * Decodes a GovalCert message from the specified reader or buffer.
+   * @param reader Reader or buffer to decode from
+   * @param [length] Message length if known beforehand
+   * @returns GovalCert
+   * @throws {Error} If the payload is not a reader or valid buffer
+   * @throws {$protobuf.util.ProtocolError} If required fields are missing
+   */
+  static decode(
+    reader: $protobuf.Reader | Uint8Array,
+    length?: number
+  ): api$GovalCert;
+
+  /**
+   * Decodes a GovalCert message from the specified reader or buffer, length delimited.
+   * @param reader Reader or buffer to decode from
+   * @returns GovalCert
+   * @throws {Error} If the payload is not a reader or valid buffer
+   * @throws {$protobuf.util.ProtocolError} If required fields are missing
+   */
+  static decodeDelimited(reader: $protobuf.Reader | Uint8Array): api$GovalCert;
+
+  /**
+   * Verifies a GovalCert message.
+   * @param message Plain object to verify
+   * @returns `null` if valid, otherwise the reason why it is not
+   */
+  static verify(message: {
+    [k: string]: any,
+  }): string | null;
+
+  /**
+   * Creates a GovalCert message from a plain object. Also converts values to their respective internal types.
+   * @param object Plain object
+   * @returns GovalCert
+   */
+  static fromObject(object: {
+    [k: string]: any,
+  }): api$GovalCert;
+
+  /**
+   * Creates a plain object from a GovalCert message. Also converts values to other types if specified.
+   * @param message GovalCert
+   * @param [options] Conversion options
+   * @returns Plain object
+   */
+  static toObject(
+    message: api$GovalCert,
+    options?: $protobuf.IConversionOptions
+  ): {
+    [k: string]: any,
+  };
+
+  /**
+   * Converts this GovalCert to JSON.
+   * @returns JSON object
+   */
+  toJSON(): {
+    [k: string]: any,
+  };
+}
+
+/**
+ * Properties of a GovalToken.
+ */
+declare type api$IGovalToken = {|
+  /**
+   * GovalToken iat
+   */
+  iat?: google$protobuf$Timestamp | google$protobuf$ITimestamp | null,
+
+  /**
+   * GovalToken exp
+   */
+  exp?: google$protobuf$Timestamp | google$protobuf$ITimestamp | null,
+
+  /**
+   * GovalToken replid
+   */
+  replid?: string | null,
+
+  /**
+   * GovalToken replToken
+   */
+  replToken?: api$ReplToken | api$IReplToken | null,
+|};
+
+/**
+ * Represents a GovalToken.
+ */
+declare class api$GovalToken {
+  /**
+   * Constructs a new GovalToken.
+   * @param [properties] Properties to set
+   */
+  constructor(properties?: api$IGovalToken): this;
+
+  /**
+   * GovalToken iat.
+   */
+  iat?: google$protobuf$Timestamp | null;
+
+  /**
+   * GovalToken exp.
+   */
+  exp?: google$protobuf$Timestamp | null;
+
+  /**
+   * GovalToken replid.
+   */
+  replid: string;
+
+  /**
+   * GovalToken replToken.
+   */
+  replToken?: api$ReplToken | null;
+
+  /**
+   * GovalToken Token.
+   */
+  Token?: "replToken";
+
+  /**
+   * Creates a new GovalToken instance using the specified properties.
+   * @param [properties] Properties to set
+   * @returns GovalToken instance
+   */
+  static create(properties?: api$IGovalToken): api$GovalToken;
+
+  /**
+   * Encodes the specified GovalToken message. Does not implicitly {@link api.GovalToken.verify|verify} messages.
+   * @param message GovalToken message or plain object to encode
+   * @param [writer] Writer to encode to
+   * @returns Writer
+   */
+  static encode(
+    message: api$GovalToken,
+    writer?: $protobuf.Writer
+  ): $protobuf.Writer;
+
+  /**
+   * Encodes the specified GovalToken message, length delimited. Does not implicitly {@link api.GovalToken.verify|verify} messages.
+   * @param message GovalToken message or plain object to encode
+   * @param [writer] Writer to encode to
+   * @returns Writer
+   */
+  static encodeDelimited(
+    message: api$GovalToken,
+    writer?: $protobuf.Writer
+  ): $protobuf.Writer;
+
+  /**
+   * Decodes a GovalToken message from the specified reader or buffer.
+   * @param reader Reader or buffer to decode from
+   * @param [length] Message length if known beforehand
+   * @returns GovalToken
+   * @throws {Error} If the payload is not a reader or valid buffer
+   * @throws {$protobuf.util.ProtocolError} If required fields are missing
+   */
+  static decode(
+    reader: $protobuf.Reader | Uint8Array,
+    length?: number
+  ): api$GovalToken;
+
+  /**
+   * Decodes a GovalToken message from the specified reader or buffer, length delimited.
+   * @param reader Reader or buffer to decode from
+   * @returns GovalToken
+   * @throws {Error} If the payload is not a reader or valid buffer
+   * @throws {$protobuf.util.ProtocolError} If required fields are missing
+   */
+  static decodeDelimited(reader: $protobuf.Reader | Uint8Array): api$GovalToken;
+
+  /**
+   * Verifies a GovalToken message.
+   * @param message Plain object to verify
+   * @returns `null` if valid, otherwise the reason why it is not
+   */
+  static verify(message: {
+    [k: string]: any,
+  }): string | null;
+
+  /**
+   * Creates a GovalToken message from a plain object. Also converts values to their respective internal types.
+   * @param object Plain object
+   * @returns GovalToken
+   */
+  static fromObject(object: {
+    [k: string]: any,
+  }): api$GovalToken;
+
+  /**
+   * Creates a plain object from a GovalToken message. Also converts values to other types if specified.
+   * @param message GovalToken
+   * @param [options] Conversion options
+   * @returns Plain object
+   */
+  static toObject(
+    message: api$GovalToken,
+    options?: $protobuf.IConversionOptions
+  ): {
+    [k: string]: any,
+  };
+
+  /**
+   * Converts this GovalToken to JSON.
    * @returns JSON object
    */
   toJSON(): {

--- a/lib/package.json
+++ b/lib/package.json
@@ -7,7 +7,7 @@
   "author": "faris@repl.it",
   "license": "MIT",
   "scripts": {
-    "prepublishOnly": "pbjs --force-number --force-message -t static-module -w default -o index.js ../api.proto ../client.proto && ./tools/jsdoc.js < index.js > .index.js && mv .index.js index.js && pbts -o index.d.ts index.js && sed -i.bak 's/constructor(/private constructor(/' index.d.ts && rm -f index.d.ts.bak && flowgen --interface-records --no-inexact --add-flow-header --output-file index.js.flow index.d.ts && sed -i.bak 's/declare var api: typeof npm\\$namespace\\$api;/export var api = npm$namespace$api;/' index.js.flow && rm -f index.js.flow.bak"
+    "prepublishOnly": "pbjs --force-number --force-message -t static-module -w default -o index.js ../api.proto ../client.proto ../signing.proto && ./tools/jsdoc.js < index.js > .index.js && mv .index.js index.js && pbts -o index.d.ts index.js && sed -i.bak 's/constructor(/private constructor(/' index.d.ts && rm -f index.d.ts.bak && flowgen --interface-records --no-inexact --add-flow-header --output-file index.js.flow index.d.ts && sed -i.bak 's/declare var api: typeof npm\\$namespace\\$api;/export var api = npm$namespace$api;/' index.js.flow && rm -f index.js.flow.bak"
   },
   "dependencies": {
     "protobufjs": "^6.10.2"

--- a/signing.proto
+++ b/signing.proto
@@ -1,0 +1,135 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+
+import "api/client.proto";
+
+package api;
+option go_package = "/api";
+
+enum TokenVersion {
+  // Body contains are bare ReplToken and must be decoded explicitly
+  BARE_REPL_TOKEN = 0;
+  // Body contains a GovalToken and can be interrogated about the type of its own
+  // message
+  TYPE_AWARE_TOKEN = 1;
+}
+
+// GovalSigningAuthority is information about a goval token, that can be used to
+// validate it. It is stored in the footer of the PASETO.
+message GovalSigningAuthority {
+  oneof cert {
+    // The ID of the root public key that was used to sign the token.
+    string key_id = 1;
+
+    // A signed PASETO with a GovalCert in the body and the GovalSigningAuthority
+    // used to sign the body in the footer.
+    string signed_cert = 2;
+  }
+
+  // An enum detailing how the body of the PASETO this is a footer of should
+  // be decoded
+  TokenVersion version = 3;
+}
+
+enum FlagClaim {
+  // Cert has the authority to sign ReplToken messages that can be validated
+  // by goval
+  MINT_GOVAL_TOKEN = 0;
+
+  // Cert has the authority to sign additional intermediate certs. (The claims
+  // on intermediate certs signed by this cert are still enforced.)
+  SIGN_INTERMEDIATE_CERT = 1;
+}
+
+// Claims are actions that a cert is allowed to do. Claims can be repeated (e.g.
+// to allow a cert to apply to multiple replids or users).
+//
+// Claims should be enforced on certificates by ensuring that certificates
+// are signed by a certificate that has a superset of claims.
+//
+// When a cert is used to sign a message, it is the responsibility of the service
+// validating the message to ensure that any requests in the message are backed
+// up by claims in the certificate. Claims in a single certificate should be
+// interpreted as a union (e.g. if replid and user is set, the token may apply
+// to any repls owned by the user, or any repls in replid, regardless of the
+// owner).
+message CertificateClaim {
+  oneof claim {
+    // This cert has the authority to sign messages on behalf of a replid
+    string replid = 1;
+    // This cert has the authority to sign messages on behalf of a user
+    string user = 2;
+    // This cert has the authority to perform an action as described in FlagClaim
+    FlagClaim flag = 3;
+  }
+}
+
+// GovalCert provides a mechanism of establishing a chain of trust without
+// requiring a single private key to be duplciated to all services that send messages.
+// The processes of generating intermediate certs is as follows:
+// - A PASETO `v2.public` root keypair is generated and added to GSM with an
+//   arbitrary key id.
+// - The root public key id is encoded in a GovalSigningAuthority
+// - An intermediate PASETO `v2.public` keypair is generated
+// - The intermediate public key is encoded in a GovalCert, along with
+//   information about the lifetime and claims of that cert.
+// - The GovalCert is encoded in the body of a PASETO and signed with the root
+//   private key. The root signing authority is inserted into the footer of the
+//   PASETO to use for validation.
+// - This signed PASETO is encoded in another GovalSigningAuthority and appended
+//   as the footer of PASETOs signed by the intermediate private key.
+// Additional intermediate certs can be generated and signed by private key and
+// signing authority of the previous cert.
+//
+// When validating a chain of certs, the footer of each wrapped PASETO is
+// recursed until reaching a root key id. The body of that PASETO is
+// validated with the root public key. The body is decoded into a GovalCert,
+// its lifetime is checked, and the public key is pulled out and used to validate
+// the next PASETO, continuing back up the chain.
+// At each step along the chain (except for the root), the claims of a certificate
+// must be verified to be a subset of the claims of the certificate signing it.
+message GovalCert {
+  // Issue timestamp. Equivalent to JWT's "iat" (Issued At) claim.  Tokens with
+  // no `iat` field will be treated as if they had been issed at the UNIX epoch
+  // (1970-01-01T00:00:00Z).
+  google.protobuf.Timestamp iat = 1;
+
+  // Expiration timestamp. Equivalent to JWT's "exp" (Expiration Time) Claim.
+  // If unset, will default to one hour after `iat`.
+  google.protobuf.Timestamp exp = 2;
+
+  // A list of claims this cert can authorize
+  repeated CertificateClaim claims = 3;
+
+  // The PASETO `v2.public` (Ed25519) public key authorized to sign requests in
+  // this scope. Must be encoded in a PEM PUBLIC KEY block.
+  // (This key is usally generated in nodejs, and nodejs does not provide an
+  // interface to get the raw key bytes)
+  string publicKey = 4;
+}
+
+// A GovalToken should be the body of any PASETO we send
+message GovalToken {
+  // Issue timestamp. Equivalent to JWT's "iat" (Issued At) claim.  Tokens with
+  // no `iat` field will be treated as if they had been issed at the UNIX epoch
+  // (1970-01-01T00:00:00Z).
+  google.protobuf.Timestamp iat = 1;
+
+  // Expiration timestamp. Equivalent to JWT's "exp" (Expiration Time) Claim.
+  // If unset, will default to one hour after `iat`.
+  google.protobuf.Timestamp exp = 2;
+
+  // Tokens are only allowed to act for a single repl, replid is the repl that
+  // this token is authorized for. The validator must check that the replid of
+  // this token agrees with the claims in any of the certs signing it.
+  string replid = 3;
+
+  // The token body, all future tokens should rely on the information in
+  // GovalToken to establish basic validity, and should only add additional
+  // fields. ReplToken has its own iat, exp, and replid for legacy reasons.
+  oneof Token {
+    // This token is used to authorize a request to create a repl in goval
+    ReplToken repl_token = 4;
+  }
+}


### PR DESCRIPTION
Add messages required to validate tokens signed by intermediate tokens, instead of only supporting tokens signed directly by the root key.