### PR TITLE
Fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# By default, just build. This prevents accidents.
+all: build
+
 bump-%:
 	OLD_VERSION=$$(git tag | sort -r --version-sort | head -n1) && \
 	SEMVER_NEW_TAG=$$(bash ./scripts/semver.sh bump $(*) $${OLD_VERSION}) && \
@@ -8,11 +11,15 @@ bump-%:
 	git commit -am "[$(*)] Bump version to $${SEMVER_NEW_TAG}" && \
 	git tag $${SEMVER_NEW_TAG}
 
-all: build bump-patch publish
-
+.PHONY: clean
 clean:
-	rm -f lib/index.d.ts lib/index.js lib/export.flow.js lib/iotester/*
+	rm -rf lib/index.d.ts lib/index.js lib/export.flow.js lib/iotester
+
+.PHONY: build
 build: clean
 	cd lib && npm install && npm run prepublishOnly
+
+.PHONY: publish
 publish:
+	$(MAKE) build bump-patch
 	cd lib && npm publish

--- a/scripts/gen.sh
+++ b/scripts/gen.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
-PATH="${PATH}:node_modules/.bin"
 
 set -e
 
-TARGET={TARGET:-"./index"}
+export PATH="${PATH}:./node_modules/.bin"
+export TARGET="${TARGET:-./index}"
+
+mkdir -p "$(dirname "${TARGET}")"
 
 pbjs \
     --force-number \
@@ -11,7 +13,7 @@ pbjs \
     -t static-module \
     -w default \
     -o "${TARGET}.js" \
-    $@
+    "$@"
 
 ./tools/jsdoc.js <"${TARGET}.js" >"${TARGET}.tmp.js"
 


### PR DESCRIPTION
This change fixes the build:

* Stops using one bashism `[[` in favor of something supported by sh
  (`:-`).
* Ensures that all directories are correctly cleaned up and created.
* Quotes `$@` to prevent accidents in the expansion (if any of the
  arguments has spaces).
* Makes `make` and `make all` not publish! That's just asking for
  accidents to happen.