### PR TITLE
Add protobuf definitions for exec lifecycle and fix roots

### DIFF
--- a/api.proto
+++ b/api.proto
@@ -844,7 +844,20 @@ message UnfollowUser {
 message Exec {
   repeated string args = 1;
   map<string, string> env = 2;
-  bool blocking = 3;
+  // Blocking is deprecated. Prefer to use lifecycle = BLOCKING instead.
+  bool blocking = 3 [deprecated = true];
+
+  enum Lifecycle {
+    // NON_BLOCKING is the default. This lets the process run in the background.
+    NON_BLOCKING = 0;
+    // BLOCKING starts and waits until the process has finished executing.
+    BLOCKING = 1;
+    // STDIN starts the process in the background and opens a pipe to stdin.
+    // TODO: Add an explicit message to be able to close the stdin.
+    STDIN = 2;
+  };
+  Lifecycle lifecycle = 6;
+
 
   // splitStderr can be set to true in order to send stderr as separate
   // messages. Note that there is no synchronization between stdout and stderr.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -481,25 +481,25 @@ export namespace api {
         public clear?: (api.Clear|null);
 
         /** Command eval. */
-        public eval: string;
+        public eval?: (string|null);
 
         /** Command result. */
-        public result: string;
+        public result?: (string|null);
 
         /** Command input. */
-        public input: string;
+        public input?: (string|null);
 
         /** Command output. */
-        public output: string;
+        public output?: (string|null);
 
         /** Command error. */
-        public error: string;
+        public error?: (string|null);
 
         /** Command stderr. */
-        public stderr: string;
+        public stderr?: (string|null);
 
         /** Command log. */
-        public log: string;
+        public log?: (string|null);
 
         /** Command saneTerm. */
         public saneTerm?: (api.SaneTerm|null);
@@ -508,7 +508,7 @@ export namespace api {
         public resizeTerm?: (api.ResizeTerm|null);
 
         /** Command state. */
-        public state: api.State;
+        public state?: (api.State|null);
 
         /** Command ok. */
         public ok?: (api.OK|null);
@@ -583,7 +583,7 @@ export namespace api {
         public testResult?: (api.TestResult|null);
 
         /** Command debuggerStart. */
-        public debuggerStart: string;
+        public debuggerStart?: (string|null);
 
         /** Command debuggerStep. */
         public debuggerStep?: (api.RunMain|null);
@@ -772,7 +772,7 @@ export namespace api {
         public fsReleaseLock?: (api.FSLock|null);
 
         /** Command hasCap. */
-        public hasCap: boolean;
+        public hasCap?: (boolean|null);
 
         /** Command pid1Config. */
         public pid1Config?: (api.Pid1Config|null);
@@ -8414,13 +8414,13 @@ export namespace api {
         private constructor(properties?: api.IOTRuneTransformOp);
 
         /** OTRuneTransformOp skip. */
-        public skip: number;
+        public skip?: (number|null);
 
         /** OTRuneTransformOp delete. */
-        public delete: number;
+        public delete?: (number|null);
 
         /** OTRuneTransformOp insert. */
-        public insert: string;
+        public insert?: (string|null);
 
         /** OTRuneTransformOp op. */
         public op?: ("skip"|"delete"|"insert");
@@ -9684,6 +9684,9 @@ export namespace api {
         /** Exec blocking */
         blocking?: (boolean|null);
 
+        /** Exec lifecycle */
+        lifecycle?: (api.Exec.Lifecycle|null);
+
         /** Exec splitStderr */
         splitStderr?: (boolean|null);
 
@@ -9708,6 +9711,9 @@ export namespace api {
 
         /** Exec blocking. */
         public blocking: boolean;
+
+        /** Exec lifecycle. */
+        public lifecycle: api.Exec.Lifecycle;
 
         /** Exec splitStderr. */
         public splitStderr: boolean;
@@ -9784,6 +9790,16 @@ export namespace api {
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };
+    }
+
+    namespace Exec {
+
+        /** Lifecycle enum. */
+        enum Lifecycle {
+            NON_BLOCKING = 0,
+            BLOCKING = 1,
+            STDIN = 2
+        }
     }
 
     /** Properties of a Package. */
@@ -12085,10 +12101,10 @@ export namespace api {
         public session: string;
 
         /** DebugInput input. */
-        public input: string;
+        public input?: (string|null);
 
         /** DebugInput adapterInput. */
-        public adapterInput: string;
+        public adapterInput?: (string|null);
 
         /** DebugInput stream. */
         public stream?: ("input"|"adapterInput");
@@ -12190,10 +12206,10 @@ export namespace api {
         public session: string;
 
         /** DebugOutput output. */
-        public output: string;
+        public output?: (string|null);
 
         /** DebugOutput adapterOutput. */
-        public adapterOutput: string;
+        public adapterOutput?: (string|null);
 
         /** DebugOutput stream. */
         public stream?: ("output"|"adapterOutput");
@@ -15231,10 +15247,10 @@ export namespace api {
         private constructor(properties?: api.IGovalSigningAuthority);
 
         /** GovalSigningAuthority keyId. */
-        public keyId: string;
+        public keyId?: (string|null);
 
         /** GovalSigningAuthority signedCert. */
-        public signedCert: string;
+        public signedCert?: (string|null);
 
         /** GovalSigningAuthority version. */
         public version: api.TokenVersion;
@@ -15342,13 +15358,13 @@ export namespace api {
         private constructor(properties?: api.ICertificateClaim);
 
         /** CertificateClaim replid. */
-        public replid: string;
+        public replid?: (string|null);
 
         /** CertificateClaim user. */
-        public user: string;
+        public user?: (string|null);
 
         /** CertificateClaim flag. */
-        public flag: api.FlagClaim;
+        public flag?: (api.FlagClaim|null);
 
         /** CertificateClaim claim. */
         public claim?: ("replid"|"user"|"flag");

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@
     var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
     
     // Exported root namespace
-    var $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
+    var $root = $protobuf.roots["./index"] || ($protobuf.roots["./index"] = {});
     
     $root.api = (function() {
     
@@ -302,59 +302,59 @@
     
             /**
              * Command eval.
-             * @member {string} eval
+             * @member {string|null|undefined} eval
              * @memberof api.Command
              * @instance
              */
-            Command.prototype["eval"] = "";
+            Command.prototype["eval"] = null;
     
             /**
              * Command result.
-             * @member {string} result
+             * @member {string|null|undefined} result
              * @memberof api.Command
              * @instance
              */
-            Command.prototype.result = "";
+            Command.prototype.result = null;
     
             /**
              * Command input.
-             * @member {string} input
+             * @member {string|null|undefined} input
              * @memberof api.Command
              * @instance
              */
-            Command.prototype.input = "";
+            Command.prototype.input = null;
     
             /**
              * Command output.
-             * @member {string} output
+             * @member {string|null|undefined} output
              * @memberof api.Command
              * @instance
              */
-            Command.prototype.output = "";
+            Command.prototype.output = null;
     
             /**
              * Command error.
-             * @member {string} error
+             * @member {string|null|undefined} error
              * @memberof api.Command
              * @instance
              */
-            Command.prototype.error = "";
+            Command.prototype.error = null;
     
             /**
              * Command stderr.
-             * @member {string} stderr
+             * @member {string|null|undefined} stderr
              * @memberof api.Command
              * @instance
              */
-            Command.prototype.stderr = "";
+            Command.prototype.stderr = null;
     
             /**
              * Command log.
-             * @member {string} log
+             * @member {string|null|undefined} log
              * @memberof api.Command
              * @instance
              */
-            Command.prototype.log = "";
+            Command.prototype.log = null;
     
             /**
              * Command saneTerm.
@@ -374,11 +374,11 @@
     
             /**
              * Command state.
-             * @member {api.State} state
+             * @member {api.State|null|undefined} state
              * @memberof api.Command
              * @instance
              */
-            Command.prototype.state = 0;
+            Command.prototype.state = null;
     
             /**
              * Command ok.
@@ -574,11 +574,11 @@
     
             /**
              * Command debuggerStart.
-             * @member {string} debuggerStart
+             * @member {string|null|undefined} debuggerStart
              * @memberof api.Command
              * @instance
              */
-            Command.prototype.debuggerStart = "";
+            Command.prototype.debuggerStart = null;
     
             /**
              * Command debuggerStep.
@@ -1078,11 +1078,11 @@
     
             /**
              * Command hasCap.
-             * @member {boolean} hasCap
+             * @member {boolean|null|undefined} hasCap
              * @memberof api.Command
              * @instance
              */
-            Command.prototype.hasCap = false;
+            Command.prototype.hasCap = null;
     
             /**
              * Command pid1Config.
@@ -21849,27 +21849,27 @@
     
             /**
              * OTRuneTransformOp skip.
-             * @member {number} skip
+             * @member {number|null|undefined} skip
              * @memberof api.OTRuneTransformOp
              * @instance
              */
-            OTRuneTransformOp.prototype.skip = 0;
+            OTRuneTransformOp.prototype.skip = null;
     
             /**
              * OTRuneTransformOp delete.
-             * @member {number} delete
+             * @member {number|null|undefined} delete
              * @memberof api.OTRuneTransformOp
              * @instance
              */
-            OTRuneTransformOp.prototype["delete"] = 0;
+            OTRuneTransformOp.prototype["delete"] = null;
     
             /**
              * OTRuneTransformOp insert.
-             * @member {string} insert
+             * @member {string|null|undefined} insert
              * @memberof api.OTRuneTransformOp
              * @instance
              */
-            OTRuneTransformOp.prototype.insert = "";
+            OTRuneTransformOp.prototype.insert = null;
     
             // OneOf field names bound to virtual getters and setters
             var $oneOfFields;
@@ -24779,6 +24779,7 @@
              * @property {Array.<string>|null} [args] Exec args
              * @property {Object.<string,string>|null} [env] Exec env
              * @property {boolean|null} [blocking] Exec blocking
+             * @property {api.Exec.Lifecycle|null} [lifecycle] Exec lifecycle
              * @property {boolean|null} [splitStderr] Exec splitStderr
              * @property {boolean|null} [splitLogs] Exec splitLogs
              */
@@ -24822,6 +24823,14 @@
              * @instance
              */
             Exec.prototype.blocking = false;
+    
+            /**
+             * Exec lifecycle.
+             * @member {api.Exec.Lifecycle} lifecycle
+             * @memberof api.Exec
+             * @instance
+             */
+            Exec.prototype.lifecycle = 0;
     
             /**
              * Exec splitStderr.
@@ -24875,6 +24884,8 @@
                     writer.uint32(/* id 4, wireType 0 =*/32).bool(message.splitStderr);
                 if (message.splitLogs != null && Object.hasOwnProperty.call(message, "splitLogs"))
                     writer.uint32(/* id 5, wireType 0 =*/40).bool(message.splitLogs);
+                if (message.lifecycle != null && Object.hasOwnProperty.call(message, "lifecycle"))
+                    writer.uint32(/* id 6, wireType 0 =*/48).int32(message.lifecycle);
                 return writer;
             };
     
@@ -24939,6 +24950,9 @@
                     case 3:
                         message.blocking = reader.bool();
                         break;
+                    case 6:
+                        message.lifecycle = reader.int32();
+                        break;
                     case 4:
                         message.splitStderr = reader.bool();
                         break;
@@ -24998,6 +25012,15 @@
                 if (message.blocking != null && message.hasOwnProperty("blocking"))
                     if (typeof message.blocking !== "boolean")
                         return "blocking: boolean expected";
+                if (message.lifecycle != null && message.hasOwnProperty("lifecycle"))
+                    switch (message.lifecycle) {
+                    default:
+                        return "lifecycle: enum value expected";
+                    case 0:
+                    case 1:
+                    case 2:
+                        break;
+                    }
                 if (message.splitStderr != null && message.hasOwnProperty("splitStderr"))
                     if (typeof message.splitStderr !== "boolean")
                         return "splitStderr: boolean expected";
@@ -25035,6 +25058,20 @@
                 }
                 if (object.blocking != null)
                     message.blocking = Boolean(object.blocking);
+                switch (object.lifecycle) {
+                case "NON_BLOCKING":
+                case 0:
+                    message.lifecycle = 0;
+                    break;
+                case "BLOCKING":
+                case 1:
+                    message.lifecycle = 1;
+                    break;
+                case "STDIN":
+                case 2:
+                    message.lifecycle = 2;
+                    break;
+                }
                 if (object.splitStderr != null)
                     message.splitStderr = Boolean(object.splitStderr);
                 if (object.splitLogs != null)
@@ -25063,6 +25100,7 @@
                     object.blocking = false;
                     object.splitStderr = false;
                     object.splitLogs = false;
+                    object.lifecycle = options.enums === String ? "NON_BLOCKING" : 0;
                 }
                 if (message.args && message.args.length) {
                     object.args = [];
@@ -25081,6 +25119,8 @@
                     object.splitStderr = message.splitStderr;
                 if (message.splitLogs != null && message.hasOwnProperty("splitLogs"))
                     object.splitLogs = message.splitLogs;
+                if (message.lifecycle != null && message.hasOwnProperty("lifecycle"))
+                    object.lifecycle = options.enums === String ? $root.api.Exec.Lifecycle[message.lifecycle] : message.lifecycle;
                 return object;
             };
     
@@ -25094,6 +25134,22 @@
             Exec.prototype.toJSON = function toJSON() {
                 return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
             };
+    
+            /**
+             * Lifecycle enum.
+             * @name api.Exec.Lifecycle
+             * @enum {number}
+             * @property {number} NON_BLOCKING=0 NON_BLOCKING value
+             * @property {number} BLOCKING=1 BLOCKING value
+             * @property {number} STDIN=2 STDIN value
+             */
+            Exec.Lifecycle = (function() {
+                var valuesById = {}, values = Object.create(valuesById);
+                values[valuesById[0] = "NON_BLOCKING"] = 0;
+                values[valuesById[1] = "BLOCKING"] = 1;
+                values[valuesById[2] = "STDIN"] = 2;
+                return values;
+            })();
     
             return Exec;
         })();
@@ -30247,19 +30303,19 @@
     
             /**
              * DebugInput input.
-             * @member {string} input
+             * @member {string|null|undefined} input
              * @memberof api.DebugInput
              * @instance
              */
-            DebugInput.prototype.input = "";
+            DebugInput.prototype.input = null;
     
             /**
              * DebugInput adapterInput.
-             * @member {string} adapterInput
+             * @member {string|null|undefined} adapterInput
              * @memberof api.DebugInput
              * @instance
              */
-            DebugInput.prototype.adapterInput = "";
+            DebugInput.prototype.adapterInput = null;
     
             // OneOf field names bound to virtual getters and setters
             var $oneOfFields;
@@ -30502,19 +30558,19 @@
     
             /**
              * DebugOutput output.
-             * @member {string} output
+             * @member {string|null|undefined} output
              * @memberof api.DebugOutput
              * @instance
              */
-            DebugOutput.prototype.output = "";
+            DebugOutput.prototype.output = null;
     
             /**
              * DebugOutput adapterOutput.
-             * @member {string} adapterOutput
+             * @member {string|null|undefined} adapterOutput
              * @memberof api.DebugOutput
              * @instance
              */
-            DebugOutput.prototype.adapterOutput = "";
+            DebugOutput.prototype.adapterOutput = null;
     
             // OneOf field names bound to virtual getters and setters
             var $oneOfFields;
@@ -37884,19 +37940,19 @@
     
             /**
              * GovalSigningAuthority keyId.
-             * @member {string} keyId
+             * @member {string|null|undefined} keyId
              * @memberof api.GovalSigningAuthority
              * @instance
              */
-            GovalSigningAuthority.prototype.keyId = "";
+            GovalSigningAuthority.prototype.keyId = null;
     
             /**
              * GovalSigningAuthority signedCert.
-             * @member {string} signedCert
+             * @member {string|null|undefined} signedCert
              * @memberof api.GovalSigningAuthority
              * @instance
              */
-            GovalSigningAuthority.prototype.signedCert = "";
+            GovalSigningAuthority.prototype.signedCert = null;
     
             /**
              * GovalSigningAuthority version.
@@ -38166,27 +38222,27 @@
     
             /**
              * CertificateClaim replid.
-             * @member {string} replid
+             * @member {string|null|undefined} replid
              * @memberof api.CertificateClaim
              * @instance
              */
-            CertificateClaim.prototype.replid = "";
+            CertificateClaim.prototype.replid = null;
     
             /**
              * CertificateClaim user.
-             * @member {string} user
+             * @member {string|null|undefined} user
              * @memberof api.CertificateClaim
              * @instance
              */
-            CertificateClaim.prototype.user = "";
+            CertificateClaim.prototype.user = null;
     
             /**
              * CertificateClaim flag.
-             * @member {api.FlagClaim} flag
+             * @member {api.FlagClaim|null|undefined} flag
              * @memberof api.CertificateClaim
              * @instance
              */
-            CertificateClaim.prototype.flag = 0;
+            CertificateClaim.prototype.flag = null;
     
             // OneOf field names bound to virtual getters and setters
             var $oneOfFields;

--- a/lib/index.js.flow
+++ b/lib/index.js.flow
@@ -1138,37 +1138,37 @@ declare class api$Command {
   /**
    * Command eval.
    */
-  eval: string;
+  eval?: string | null;
 
   /**
    * Command result.
    */
-  result: string;
+  result?: string | null;
 
   /**
    * Command input.
    */
-  input: string;
+  input?: string | null;
 
   /**
    * Command output.
    */
-  output: string;
+  output?: string | null;
 
   /**
    * Command error.
    */
-  error: string;
+  error?: string | null;
 
   /**
    * Command stderr.
    */
-  stderr: string;
+  stderr?: string | null;
 
   /**
    * Command log.
    */
-  log: string;
+  log?: string | null;
 
   /**
    * Command saneTerm.
@@ -1183,7 +1183,7 @@ declare class api$Command {
   /**
    * Command state.
    */
-  state: $Values<typeof api$State>;
+  state?: $Values<typeof api$State> | null;
 
   /**
    * Command ok.
@@ -1308,7 +1308,7 @@ declare class api$Command {
   /**
    * Command debuggerStart.
    */
-  debuggerStart: string;
+  debuggerStart?: string | null;
 
   /**
    * Command debuggerStep.
@@ -1623,7 +1623,7 @@ declare class api$Command {
   /**
    * Command hasCap.
    */
-  hasCap: boolean;
+  hasCap?: boolean | null;
 
   /**
    * Command pid1Config.
@@ -11834,17 +11834,17 @@ declare class api$OTRuneTransformOp {
   /**
    * OTRuneTransformOp skip.
    */
-  skip: number;
+  skip?: number | null;
 
   /**
    * OTRuneTransformOp delete.
    */
-  delete: number;
+  delete?: number | null;
 
   /**
    * OTRuneTransformOp insert.
    */
-  insert: string;
+  insert?: string | null;
 
   /**
    * OTRuneTransformOp op.
@@ -13527,6 +13527,11 @@ declare type api$IExec = {|
   blocking?: boolean | null,
 
   /**
+   * Exec lifecycle
+   */
+  lifecycle?: $Values<typeof api$Exec$Lifecycle> | null,
+
+  /**
    * Exec splitStderr
    */
   splitStderr?: boolean | null,
@@ -13563,6 +13568,11 @@ declare class api$Exec {
    * Exec blocking.
    */
   blocking: boolean;
+
+  /**
+   * Exec lifecycle.
+   */
+  lifecycle: $Values<typeof api$Exec$Lifecycle>;
 
   /**
    * Exec splitStderr.
@@ -13660,7 +13670,18 @@ declare class api$Exec {
   toJSON(): {
     [k: string]: any,
   };
+  static Lifecycle: typeof api$Exec$Lifecycle;
 }
+
+/**
+ * Lifecycle enum.
+ */
+
+declare var api$Exec$Lifecycle: {|
+  +NON_BLOCKING: 0, // 0
+  +BLOCKING: 1, // 1
+  +STDIN: 2, // 2
+|};
 
 /**
  * Properties of a Package.
@@ -16736,12 +16757,12 @@ declare class api$DebugInput {
   /**
    * DebugInput input.
    */
-  input: string;
+  input?: string | null;
 
   /**
    * DebugInput adapterInput.
    */
-  adapterInput: string;
+  adapterInput?: string | null;
 
   /**
    * DebugInput stream.
@@ -16877,12 +16898,12 @@ declare class api$DebugOutput {
   /**
    * DebugOutput output.
    */
-  output: string;
+  output?: string | null;
 
   /**
    * DebugOutput adapterOutput.
    */
-  adapterOutput: string;
+  adapterOutput?: string | null;
 
   /**
    * DebugOutput stream.
@@ -21026,12 +21047,12 @@ declare class api$GovalSigningAuthority {
   /**
    * GovalSigningAuthority keyId.
    */
-  keyId: string;
+  keyId?: string | null;
 
   /**
    * GovalSigningAuthority signedCert.
    */
-  signedCert: string;
+  signedCert?: string | null;
 
   /**
    * GovalSigningAuthority version.
@@ -21180,17 +21201,17 @@ declare class api$CertificateClaim {
   /**
    * CertificateClaim replid.
    */
-  replid: string;
+  replid?: string | null;
 
   /**
    * CertificateClaim user.
    */
-  user: string;
+  user?: string | null;
 
   /**
    * CertificateClaim flag.
    */
-  flag: $Values<typeof api$FlagClaim>;
+  flag?: $Values<typeof api$FlagClaim> | null;
 
   /**
    * CertificateClaim claim.

--- a/lib/iotester/index.js
+++ b/lib/iotester/index.js
@@ -14,7 +14,7 @@
     var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
     
     // Exported root namespace
-    var $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
+    var $root = $protobuf.roots["./iotester/index"] || ($protobuf.roots["./iotester/index"] = {});
     
     $root.api = (function() {
     

--- a/scripts/gen.sh
+++ b/scripts/gen.sh
@@ -13,6 +13,7 @@ pbjs \
     -t static-module \
     -w default \
     -o "${TARGET}.js" \
+    --root "${TARGET}" \
     "$@"
 
 ./tools/jsdoc.js <"${TARGET}.js" >"${TARGET}.tmp.js"


### PR DESCRIPTION
This pr does 2 things:

1. Added the lifecycle enum to Exec.
2. Fixes some crazy bug caused by how the protobuf definitions are exported.  For some reason google uses a global registry, so only one namespace (in this case, `api`) can exist in the same "root."   